### PR TITLE
Fix locales routing using locales package

### DIFF
--- a/back/pkg/ion18n/ion18n.go
+++ b/back/pkg/ion18n/ion18n.go
@@ -20,8 +20,11 @@ func NewIon18nRouter(router *gin.RouterGroup, ionPath string) (*Ion18nRouter, er
 	// is there any advantage of gin-contrib/static over the default router.Static?
 	//i.router.Use(static.Serve("/en-US/", static.LocalFile(i.ionPath + "/en-US/", true)))
 	//i.router.Use(static.Serve("/de/", static.LocalFile(i.ionPath + "/de/", true)))
-	i.router.Static("en-US/", i.ionPath+"/en-US/")
-	i.router.Static("de/", i.ionPath+"/de/")
+
+	for _, tag := range locales.GetSupportedLocales() {
+		base, _ :=tag.Base()
+		i.router.Static(base.String()+"/", i.ionPath+"/"+base.String()+"/")
+	}
 
 	return &i, nil
 }
@@ -29,6 +32,7 @@ func NewIon18nRouter(router *gin.RouterGroup, ionPath string) (*Ion18nRouter, er
 func (i *Ion18nRouter) HandleRequest(c *gin.Context) {
 
 	bestMatch := locales.GetBestSupportedLocale(c.GetHeader("Accept-Language"))
+
 	c.Redirect(http.StatusTemporaryRedirect, "/"+bestMatch+"/")
 
 }

--- a/back/pkg/locales/locales.go
+++ b/back/pkg/locales/locales.go
@@ -9,12 +9,18 @@ var supportedLocales = []language.Tag{
 	language.German,
 }
 
+func GetSupportedLocales() []language.Tag {
+	return supportedLocales
+}
+
 func GetBestSupportedLocale(locale string) string {
 	matcher := language.NewMatcher(supportedLocales)
 
 	lang := language.Make(locale)
 
 	tag, _, _ := matcher.Match(lang)
+	base, _ := tag.Base()
 
-	return tag.String()
+
+	return base.String()
 }

--- a/back/pkg/locales/locales_test.go
+++ b/back/pkg/locales/locales_test.go
@@ -1,6 +1,9 @@
 package locales
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestGetBestSupportedLocale(t *testing.T) {
 	french := "fr"
@@ -38,4 +41,12 @@ func TestGetBestSupportedLocale(t *testing.T) {
 		t.Error("expected german for de-de")
 	}
 
+}
+
+func TestGetSupportedLocales(t *testing.T) {
+	supported := GetSupportedLocales()
+
+	if !reflect.DeepEqual(supported, supportedLocales) {
+		t.Error("should be equal")
+	}
 }

--- a/back/pkg/locales/locales_test.go
+++ b/back/pkg/locales/locales_test.go
@@ -8,8 +8,9 @@ func TestGetBestSupportedLocale(t *testing.T) {
 	swissGerman := "gsw"
 	americanEnglish := "en-US"
 	english := "en"
+	germanGerman := "de-DE"
 
-	if GetBestSupportedLocale(french) != "en-US" {
+	if GetBestSupportedLocale(french) != "en" {
 		t.Error("fallback should be american english")
 	}
 
@@ -21,16 +22,20 @@ func TestGetBestSupportedLocale(t *testing.T) {
 		t.Error("fallback for swiss german should be german")
 	}
 
-	if GetBestSupportedLocale(americanEnglish) != "en-US" {
+	if GetBestSupportedLocale(americanEnglish) != "en" {
 		t.Error("language for american english should be english")
 	}
 
-	if GetBestSupportedLocale(english) != "en-US" {
+	if GetBestSupportedLocale(english) != "en" {
 		t.Error("fallback for english should be american english")
 	}
 
-	if GetBestSupportedLocale("") != "en-US" {
+	if GetBestSupportedLocale("") != "en" {
 		t.Error("fallback for no locale should be american english")
+	}
+
+	if GetBestSupportedLocale(germanGerman) != "de" {
+		t.Error("expected german for de-de")
 	}
 
 }

--- a/back/pkg/osm/Controller_test.go
+++ b/back/pkg/osm/Controller_test.go
@@ -103,7 +103,7 @@ func TestController_GetRoute_3(t *testing.T) {
 	}, latlng.LatLngLiteral{
 		Lat: 49.50,
 		Lng: 11.2,
-	}, "en-US").Return([]Route{{}}, nil)
+	}, "en").Return([]Route{{}}, nil)
 	os.Setenv("OPENSTREETMAP_BOUNDS", "49.4126,11.0111;49.5118,11.2167")
 	env := env2.NewEnv()
 	router := gin.Default()
@@ -132,7 +132,7 @@ func TestController_GetRoute_4(t *testing.T) {
 	}, latlng.LatLngLiteral{
 		Lat: 49.50,
 		Lng: 11.2,
-	}, "en-US").Return(nil, errors.New("new error"))
+	}, "en").Return(nil, errors.New("new error"))
 	os.Setenv("OPENSTREETMAP_BOUNDS", "49.4126,11.0111;49.5118,11.2167")
 	env := env2.NewEnv()
 	router := gin.Default()

--- a/front/angular.json
+++ b/front/angular.json
@@ -11,7 +11,7 @@
       "prefix": "app",
       "schematics": {},
       "i18n": {
-        "sourceLocale": "en-US",
+        "sourceLocale": "en",
         "locales": {
           "de": "src/locale/messages.de.xlf"
         }


### PR DESCRIPTION
Locales routing was broken due to mixing base and non-base
languages. Switch to base languages like en and de instead of
en-US.